### PR TITLE
Fix a bug in the STFS block number algorithm

### DIFF
--- a/py360/stfs.py
+++ b/py360/stfs.py
@@ -180,7 +180,7 @@ class STFS(object):
 
         if block_num >= 0xAA:
             block_adjust += ((block_num // 0xAA)) + 1 << self.table_size_shift
-        if block_num > 0x70E4:
+        if block_num >= 0x70E4:
             block_adjust += ((block_num // 0x70E4) + 1)<< self.table_size_shift
         return block_adjust + block_num
     


### PR DESCRIPTION
Thank you so much for this code! It's been immensely helpful for me to understand the STFS format.

While I was working with some larger STFS files, I came across this error in the data block to real block conversion code.
It is causing a single block next to the L2 hash block (around the 108 MB mark IIRC), if present, to be read from the wrong location.

I further verified that the change is correct using a Rock Band DLC file -- an audio file inside (an Ogg Vorbis file) extracted with `stfs.py` was reporting corrupted data via `ogginfo`, which went away after the patch was applied.